### PR TITLE
Make Frame Size Calculation work for multi-line labels

### DIFF
--- a/STTweetLabel/STTweetLabel.m
+++ b/STTweetLabel/STTweetLabel.m
@@ -235,7 +235,7 @@
     if (_cleanText == nil)
         return CGSizeZero;
 
-    return [_textStorage.attributedString boundingRectWithSize:CGSizeMake(width, CGFLOAT_MAX) options:NSStringDrawingUsesLineFragmentOrigin context:nil].size;
+    return [_textStorage.attributedString boundingRectWithSize:CGSizeMake(width, CGFLOAT_MAX) options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading context:nil].size;
 }
 
 #pragma mark -


### PR DESCRIPTION
`suggestedFrameSizeToFitEntireStringConstraintedToWidth:` wasn't working well for me. This seemed to solve it.
