### PR TITLE
Removed the frame setting in 'updateText'.

### DIFF
--- a/STTweetLabel/STTweetLabel.m
+++ b/STTweetLabel/STTweetLabel.m
@@ -225,8 +225,6 @@
     _textView.textContainer.lineFragmentPadding = 0;
     _textView.textContainerInset = UIEdgeInsetsZero;
     _textView.userInteractionEnabled = NO;
-    [_textView sizeToFit];
-    self.frame = CGRectMake(self.frame.origin.x, self.frame.origin.y, self.frame.size.width, _textView.frame.size.height);
     [self addSubview:_textView];
 }
 
@@ -237,7 +235,7 @@
     if (_cleanText == nil)
         return CGSizeZero;
 
-    return [_textStorage.attributedString boundingRectWithSize:CGSizeMake(width, CGFLOAT_MAX) options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading context:nil].size;
+    return [_textView sizeThatFits:CGSizeMake(width, CGFLOAT_MAX)];
 }
 
 #pragma mark -


### PR DESCRIPTION
Removed the frame setting in 'updateText'. I really don't think a view should be randomly updating it's own frame like that unexpectedly. Definitely not in an autolayout world. (Please correct me if I'm incorrect in that belief.)  `sizeToFit` was causing me troubles with not giving the textView enough width. Setting the frame was causing some height cut off issues. I think it makes the most sense to expect users to use `suggestedFrameSizeToFitEntireStringConstraintedToWidth` and set the correct frame. Alternatively, we could perhaps override `intrinsicContentSize` and run the 'sizeThatFits' calculation with the `preferredMaxLayoutWidth` setting on the label.

Also changed t 'suggestedFrameSizeToFitEntireStringConstraintedToWidth' to just use the proper method on '_textView' 'sizeThatFits'. Believe that's the most appropriate way to get an accurate height, though UITextView is probably using similar code to what was already there internally. It's definitely cleaner this way, and hopefully future proofs in case they update internally how that's calculated.
