### PR TITLE
support mentions preceded by a dot (or other special chars)

### DIFF
--- a/STTweetLabel/STTweetLabel.m
+++ b/STTweetLabel/STTweetLabel.m
@@ -154,7 +154,7 @@
 
         [tmpText replaceCharactersInRange:range withString:@"%"];
         // If the hot character is not preceded by a alphanumeric characater, ie email (sebastien@world.com)
-        if (range.location > 0 && [tmpText characterAtIndex:range.location - 1] != ' ' && [tmpText characterAtIndex:range.location - 1] != '\n')
+        if (range.location > 0 && [validCharactersSet characterIsMember:[tmpText characterAtIndex:range.location - 1]])
             continue;
 
         // Determine the length of the hot word


### PR DESCRIPTION
this highlights mentions after a dot (eg: .@user) which is a fairly common pattern, while still recognizing the vast majority of valid email addresses.
