### PR TITLE
Import UIKit

### DIFF
--- a/STTweetLabel/STTweetLabel.h
+++ b/STTweetLabel/STTweetLabel.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2013 Sebastien Thiebaud. All rights reserved.
 //
 
+#import <UIKit/UIKit.h>
+
 typedef enum {
     STTweetHandle = 0,
     STTweetHashtag,


### PR DESCRIPTION
Import UIKit.h to resolve a compile error caused by missing UILabel.