### PR TITLE
Make enum available to swift

### DIFF
--- a/STTweetLabel/STTweetLabel.h
+++ b/STTweetLabel/STTweetLabel.h
@@ -6,11 +6,11 @@
 //  Copyright (c) 2013 Sebastien Thiebaud. All rights reserved.
 //
 
-typedef enum {
+typedef NS_ENUM(NSInteger, STTweetHotWord) {
     STTweetHandle = 0,
     STTweetHashtag,
     STTweetLink
-} STTweetHotWord;
+};
 
 @interface STTweetLabel : UILabel
 


### PR DESCRIPTION
https://developer.apple.com/library/ios/documentation/Swift/Conceptual/BuildingCocoaApps/InteractingWithCAPIs.html -> Enumerations:

```
Swift imports as a Swift enumeration any C-style enumeration marked with the NS_ENUM macro.
```