### PR TITLE
Added support for custom hot words

### DIFF
--- a/STTweetLabel/STTweetLabel.h
+++ b/STTweetLabel/STTweetLabel.h
@@ -11,12 +11,14 @@
 typedef NS_ENUM(NSInteger, STTweetHotWord) {
     STTweetHandle = 0,
     STTweetHashtag,
-    STTweetLink
+    STTweetLink,
+    STTweetRange
 };
 
 @interface STTweetLabel : UILabel
 
 @property (nonatomic, strong) NSArray *validProtocols;
+@property (nonatomic, strong) NSArray *customHotWordRanges;
 @property (nonatomic, assign) BOOL leftToRight;
 @property (nonatomic, assign) BOOL textSelectable;
 @property (nonatomic, strong) UIColor *selectionColor;

--- a/STTweetLabel/STTweetLabel.m
+++ b/STTweetLabel/STTweetLabel.m
@@ -27,6 +27,7 @@
 @property (nonatomic, strong) NSDictionary *attributesHandle;
 @property (nonatomic, strong) NSDictionary *attributesHashtag;
 @property (nonatomic, strong) NSDictionary *attributesLink;
+@property (nonatomic, strong) NSDictionary *attributesRange;
 
 @property (strong) UITextView *textView;
 
@@ -129,8 +130,10 @@
     _attributesHandle = @{NSForegroundColorAttributeName: [UIColor redColor], NSFontAttributeName: [UIFont fontWithName:@"HelveticaNeue" size:14.0]};
     _attributesHashtag = @{NSForegroundColorAttributeName: [[UIColor alloc] initWithWhite:170.0/255.0 alpha:1.0], NSFontAttributeName: [UIFont fontWithName:@"HelveticaNeue" size:14.0]};
     _attributesLink = @{NSForegroundColorAttributeName: [[UIColor alloc] initWithRed:129.0/255.0 green:171.0/255.0 blue:193.0/255.0 alpha:1.0], NSFontAttributeName: [UIFont fontWithName:@"HelveticaNeue" size:14.0]};
+    _attributesRange = @{NSForegroundColorAttributeName: [[UIColor alloc] initWithRed:0.0/255.0 green:255.0/255.0 blue:0.0/255.0 alpha:1.0], NSFontAttributeName: [UIFont fontWithName:@"HelveticaNeue" size:14.0]};
     
     self.validProtocols = @[@"http", @"https"];
+    self.customHotWordRanges = @[];
 }
 
 #pragma mark - Printing and calculating text
@@ -196,6 +199,11 @@
         // Register the hot word and its range
         if (length > 1)
             [_rangesOfHotWords addObject:@{@"hotWord": @(hotWord), @"range": [NSValue valueWithRange:NSMakeRange(range.location, length)]}];
+    }
+    
+    // Add custom hot word ranges
+    for (NSValue *range in self.customHotWordRanges) {
+        [_rangesOfHotWords addObject:@{@"hotWord": @(STTweetRange), @"range": range}];
     }
 
     [self determineLinks];
@@ -273,6 +281,11 @@
     [self determineHotWords];
 }
 
+- (void)setCustomHotWordRanges:(NSArray *)customHotWordRanges {
+    _customHotWordRanges = customHotWordRanges;
+    [self determineHotWords];
+}
+
 - (void)setAttributes:(NSDictionary *)attributes {
     if (!attributes[NSFontAttributeName]) {
         NSMutableDictionary *copy = [attributes mutableCopy];
@@ -313,6 +326,9 @@
             break;
         case STTweetLink:
             _attributesLink = attributes;
+            break;
+        case STTweetRange:
+            _attributesRange = attributes;
             break;
         default:
             break;
@@ -367,7 +383,10 @@
 
         case STTweetLink:
             return _attributesLink;
-
+        
+        case STTweetRange:
+            return _attributesRange;
+            
         default:
             break;
     }

--- a/STTweetLabel/STTweetLabel.m
+++ b/STTweetLabel/STTweetLabel.m
@@ -133,7 +133,6 @@
     _attributesRange = @{NSForegroundColorAttributeName: [[UIColor alloc] initWithRed:0.0/255.0 green:255.0/255.0 blue:0.0/255.0 alpha:1.0], NSFontAttributeName: [UIFont fontWithName:@"HelveticaNeue" size:14.0]};
     
     self.validProtocols = @[@"http", @"https"];
-    self.customHotWordRanges = @[];
 }
 
 #pragma mark - Printing and calculating text
@@ -203,7 +202,10 @@
     
     // Add custom hot word ranges
     for (NSValue *range in self.customHotWordRanges) {
-        [_rangesOfHotWords addObject:@{@"hotWord": @(STTweetRange), @"range": range}];
+        NSRange textRange = NSMakeRange(0, tmpText.length);
+        if (NSLocationInRange([range rangeValue].location, textRange) && NSLocationInRange(NSMaxRange([range rangeValue]), textRange)) {
+            [_rangesOfHotWords addObject:@{@"hotWord": @(STTweetRange), @"range": range}];
+        }
     }
 
     [self determineLinks];
@@ -283,7 +285,6 @@
 
 - (void)setCustomHotWordRanges:(NSArray *)customHotWordRanges {
     _customHotWordRanges = customHotWordRanges;
-    [self determineHotWords];
 }
 
 - (void)setAttributes:(NSDictionary *)attributes {

--- a/STTweetLabelExample/STTweetLabel Tests/STTweetLabel_Tests.m
+++ b/STTweetLabelExample/STTweetLabel Tests/STTweetLabel_Tests.m
@@ -106,6 +106,15 @@
     XCTAssertEqualObjects(attributes, [_tweetLabel attributesForHotWord:STTweetLink], @"Link attributes should be %@ but %@ was returned instead.", attributes, [_tweetLabel attributesForHotWord:STTweetLink]);
 }
 
+- (void)test_setAndGetAttributesForRange_setAttributes_attributes
+{
+    NSDictionary *attributes = @{NSForegroundColorAttributeName: [UIColor redColor], NSFontAttributeName: [UIFont fontWithName:@"HelveticaNeue" size:14.0]};
+    
+    [_tweetLabel setAttributes:attributes hotWord:STTweetRange];
+    
+    XCTAssertEqualObjects(attributes, [_tweetLabel attributesForHotWord:STTweetRange], @"Range attributes should be %@ but %@ was returned instead.", attributes, [_tweetLabel attributesForHotWord:STTweetRange]);
+}
+
 - (void)test_setAndGetAttributesForText_setValidAttributes_exceptionNotThrown
 {
     NSDictionary *attributes = @{NSForegroundColorAttributeName: [UIColor redColor], NSFontAttributeName: [UIFont fontWithName:@"HelveticaNeue" size:14.0]};
@@ -361,6 +370,18 @@
     [self initiateTestFromSample:string results:results];
     
     _tweetLabel.validProtocols = originalValidProtocols;
+}
+
+- (void)test_setTextAndGetHotWords_setTextWithCustomRange_hotWords
+{
+    NSValue *rangeValue = [NSValue valueWithRange:NSMakeRange(0, 3)];
+    _tweetLabel.customHotWordRanges = @[rangeValue];
+    
+    NSString *string = @"The first word in this sentance should be a hot word.";
+    NSArray *results = @[
+                         @{@"hotWord": @(STTweetRange), @"range": rangeValue}
+                         ];
+    [self initiateTestFromSample:string results:results];
 }
 
 @end

--- a/STTweetLabelExample/STTweetLabelExample.xcodeproj/project.xcworkspace/xcshareddata/STTweetLabelExample.xccheckout
+++ b/STTweetLabelExample/STTweetLabelExample.xcodeproj/project.xcworkspace/xcshareddata/STTweetLabelExample.xccheckout
@@ -7,21 +7,21 @@
 	<key>IDESourceControlProjectIdentifier</key>
 	<string>07C12E3B-50A0-45B9-AA7F-923C04908480</string>
 	<key>IDESourceControlProjectName</key>
-	<string>STTweetLabelExample</string>
+	<string>project</string>
 	<key>IDESourceControlProjectOriginsDictionary</key>
 	<dict>
 		<key>5588B72F2A481BE0CAEACFD6561144A2DA93EB0B</key>
-		<string>github.com:SebastienThiebaud/STTweetLabel</string>
+		<string>https://github.com/jallen/STTweetLabel.git</string>
 	</dict>
 	<key>IDESourceControlProjectPath</key>
-	<string>STTweetLabelExample/STTweetLabelExample.xcodeproj</string>
+	<string>STTweetLabelExample/STTweetLabelExample.xcodeproj/project.xcworkspace</string>
 	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
 	<dict>
 		<key>5588B72F2A481BE0CAEACFD6561144A2DA93EB0B</key>
 		<string>../../..</string>
 	</dict>
 	<key>IDESourceControlProjectURL</key>
-	<string>github.com:SebastienThiebaud/STTweetLabel</string>
+	<string>https://github.com/jallen/STTweetLabel.git</string>
 	<key>IDESourceControlProjectVersion</key>
 	<integer>111</integer>
 	<key>IDESourceControlProjectWCCIdentifier</key>

--- a/STTweetLabelExample/STTweetLabelExample/STViewController.m
+++ b/STTweetLabelExample/STTweetLabelExample/STViewController.m
@@ -24,10 +24,12 @@
     
     self.tweetLabel.text = @"Hi. This is a new tool for @you! Developed by @SebThiebaud for #iPhone #ObjC... and #iOS7 ;-) My GitHub page: https://t.co/pQXDoiYA";
     self.tweetLabel.textAlignment = NSTextAlignmentLeft;
+    self.tweetLabel.customHotWordRanges = @[[NSValue valueWithRange:NSMakeRange(0, 3)],
+                                            [NSValue valueWithRange:[self.tweetLabel.text rangeOfString:@"GitHub"]]];
 
     self.tweetLabel.detectionBlock = ^(STTweetHotWord hotWord, NSString *string, NSString *protocol, NSRange range) {
 
-        NSArray *hotWords = @[@"Handle", @"Hashtag", @"Link"];
+        NSArray *hotWords = @[@"Handle", @"Hashtag", @"Link", @"Range"];
         _displayLabel.text = [NSString stringWithFormat:@"%@ [%d,%d]: %@%@", hotWords[hotWord], (int)range.location, (int)range.length, string, (protocol != nil) ? [NSString stringWithFormat:@" *%@*", protocol] : @""];
     };
 }


### PR DESCRIPTION
Hi, 

I needed support for this for one of my projects. 
Thought it might be helpful for others. 
I tried to keep the code somewhat consistent. 

Set an array of ranges (NSValues) for the customHotWordRanges property on the label. Then those ranges will be detected with type STTweetRange in the detection block when tapped.