### PR TITLE
Fix issue with autolayout

### DIFF
--- a/STTweetLabel/STTweetLabel.m
+++ b/STTweetLabel/STTweetLabel.m
@@ -260,6 +260,11 @@
 
 #pragma mark - Setters
 
+- (void)setBounds:(CGRect)bounds {
+    [super setBounds:bounds];
+    [self invalidateIntrinsicContentSize];
+}
+
 - (void)setText:(NSString *)text {
     [super setText:@""];
     _cleanText = text;


### PR DESCRIPTION
Invalidate the instrinsic content size when the view's bounds change,
which will force another layout pass and calculate a new height.  Fixes
issues with using this in a dynamically sized table view cell.

Fixes #144