### PR TITLE
text view shouldn't be editable to prevent selection with TAB on hardware keyboard

### DIFF
--- a/STTweetLabel/STTweetLabel.m
+++ b/STTweetLabel/STTweetLabel.m
@@ -82,6 +82,7 @@
     _textView.textContainer.lineFragmentPadding = 0;
     _textView.textContainerInset                = UIEdgeInsetsZero;
     _textView.userInteractionEnabled            = NO;
+    _textView.editable                          = NO;
     [self addSubview:_textView];
 }
 


### PR DESCRIPTION
If you have a hardware keyboard pressing TAB will select a UITextView inside STTweetLabel. It can be then edited which etc. This commit fixes it
